### PR TITLE
Fix broken links in MainNavbar component

### DIFF
--- a/src/components/MainNavbar.jsx
+++ b/src/components/MainNavbar.jsx
@@ -20,11 +20,11 @@ const MainNavbar = () => {
     },
     {
       tab: "Community",
-      page: "/upcoming",
+      page: "/error",
     },
     {
       tab: "Pro",
-      page: "/upcoming",
+      page: "/error",
     },
   ];
 


### PR DESCRIPTION
Refactor the MainNavbar component to fix broken links. The "Community" and "Pro" tabs were previously pointing to the "/upcoming" page, but have been updated to point to the "/error" page. This ensures that the links in the MainNavbar component are correctly directing users to the intended pages.

Here is  the Video Demonstrating the changes 
https://drive.google.com/uc?id=1F0x0lK3y-Em_d7pH7umEuH2Rhjh2KR3K&export=download

Hey @arjunatapadkar , Please have a look into the changes.