### PR TITLE
[Bug]: Updated code to make logo center of '/cheats route'

### DIFF
--- a/src/components/landing page/Navbarm.jsx
+++ b/src/components/landing page/Navbarm.jsx
@@ -65,16 +65,18 @@ const Navbarm = () => {
             </ul>
           </details>
 
-          <button onClick={() => setDark(!dark)} className="text-3xl">
-            {dark ? <CiLight className="" /> : <MdDarkMode />}
-          </button>
-
           <Link to="/" className="flex items-center">
             <img src={logo} loading="lazy" className="w-[50px]" />
             <span className="text-3xl pl-2 font-bold text-white">
               Codeteria
             </span>
-          </Link>
+          </Link>.
+
+          <button onClick={() => setDark(!dark)} className="text-3xl">
+            {dark ? <CiLight className="" /> : <MdDarkMode />}
+          </button>
+
+ 
         </div>
 
         {/* Desktop Navbar */}


### PR DESCRIPTION
### Title
**Logo of route "/cheats" should be in center.**
**Fixes** #93 
### Screenshot

- Before

![image](https://github.com/user-attachments/assets/27952fa9-9141-49f2-8fca-752aff2259d1)

- After

<img width="959" alt="image" src="https://github.com/user-attachments/assets/8c626698-7db8-4353-af54-41c6b213bbec">


